### PR TITLE
Adrian's review: SFC OAM

### DIFF
--- a/draft-ietf-teas-5g-ns-ip-mpls.md
+++ b/draft-ietf-teas-5g-ns-ip-mpls.md
@@ -1817,12 +1817,6 @@ From    │ DC 1 │ DC 2 │ DC 3 │Total from DC │
       of network slicing. Providers that deploy network slicing
       capabilities should be able to select whatever OAM technology or specific feature that would address their needs.
 
-      SFC OAM {{?RFC9451}} should also be supported
-      for slices that make uses of service function chaining
-      {{?RFC7665}}. An example of SFC OAM technique to Continuity
-      Check, Connectivity Verification, or tracing service functions
-      is specified in {{?RFC9516}}.
-
    *  Providers may want to enable differentiated failure
       detect and repair features for a subset of network
       slices. For example, a given Network Slice may require fast detect and


### PR DESCRIPTION
> 
> 8.
> 
>       SFC OAM [RFC9451] should also be supported for slices that
> make
>       uses of service function chaining [RFC7665].  An example of
> SFC
>       OAM technique to Continuity Check, Connectivity
> Verification, or
>       tracing service functions is specified in [RFC9516].
> 
> This paragraph is completely true. But why is it here? You have
> not mentioned SFC anywhere in the document.