### PR TITLE
Adrian's review: Figure 14

### DIFF
--- a/draft-ietf-teas-5g-ns-ip-mpls.md
+++ b/draft-ietf-teas-5g-ns-ip-mpls.md
@@ -624,14 +624,14 @@ This document does not describe in detail how to manage an L2VPN or L3VPN, as th
         (not slice specific)     for S-NSSAI
     <───────────────────────────> <───────>
    ┌────┬────┬────┬────┬────┬────┬────┬────┐
-   │2001:0db8:xxxx:xxxx:xxxx:xxxx:ttdd:dddd│
+   │xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:ttdd:dddd│
    └─────────┴─────────┴─────────┴─────────┘
     tt     - SST (8 bits)
     dddddd - SD (24 bits)
 ~~~
-{: #figure-11 title="An Example of S-NSSAI Embedded into IPv6" artwork-align="center"}
+{: #figure-11 title="An Example of S-NSSAI Embedded into an IPv6 Address" artwork-align="center"}
 
-   In the example shown in {{figure-11}}, the most significant 96 bits of the IPv6 address
+   In reference to {{figure-11}}, the most significant 96 bits of the IPv6 address
    are unique to the NF, but do not carry any slice-specific information. The S-NSSAI information is embedded in the least
    significant 32 bits. The 96-bit part of the address may be structured by the provider, for example, on the
    geographical location or the DC identification.


### PR DESCRIPTION
> Figure 14
> 
> I see why you have used 2001:0db8
> Well done for using a documentation range.
> However, your "example" then moves on to use x, t, and d So I
> think you are not really doing an example so much as showing the
> format and you could go to:
>    xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:ttdd:dddd
> And not say "example".
> 
> Figure 15 is a different matter, and is good with the
> documentation range.
>