### PR TITLE
Adrian's review: intrinsic shortcomings

### DIFF
--- a/draft-ietf-teas-5g-ns-ip-mpls.md
+++ b/draft-ietf-teas-5g-ns-ip-mpls.md
@@ -521,7 +521,7 @@ This document does not describe in detail how to manage an L2VPN or L3VPN, as th
 
    More details about the mapping between 3GPP and RFC 9543 Network Slices is provided in {{?I-D.ietf-teas-5g-network-slice-application}}.
    That document includes additional methods for mapping 5G slices to TN slices (e.g., source UDP port number), but these
-   methods are not reproduced here because of the intrinsic shortcomings of these methods.
+   methods are not discussed here because of the shortcomings of these methods (e.g., load balancing, NAT).
 
 ##  VLAN Hand-off {#sec-vlan-handoff}
 


### PR DESCRIPTION
> 4.
> 
>    these methods are not
>    reproduced here because of the intrinsic shortcomings of these
>    methods.
> 
> I think probably s/reproduced/discussed/
> 
> Now, you say "intrinsic shortcomings" and some might find that
> pejorative. Does draft-ietf-teas-5g-network-slice-application
> describe those shortcomings? If so, you might just include a
> pointer. Otherwise, you either have to describe the shortcomings
> (not recommended) or simplify the text because we are not
> interested in what you don't do and more interested in what you
> do do (and why).