### PR TITLE
Adrian's review: Section 3.2

### DIFF
--- a/draft-ietf-teas-5g-ns-ip-mpls.md
+++ b/draft-ietf-teas-5g-ns-ip-mpls.md
@@ -215,10 +215,10 @@ The term "Transport Network" is used for disambiguation with 5G network (e.g., I
 
 ##  5G Network Slicing versus Transport Network Slicing {#sec-5gtn}
 
-   Network slicing has a different meaning in the 3GPP mobile and transport
-   worlds.  Hence, for the sake of precision and without seeking to be exhaustive, this section provides a
-   brief description of the objectives of 5G Network Slicing and
-   Transport Network Slicing:
+   Network slicing has a different meaning in the 3GPP mobile world and transport
+   world. This difference can be seen from the descriptions below that set out
+   the objectives of 5G Network Slicing and Transport Network
+   Slicing. These descriptions are not intended to be exhaustive.
 
    * 5G Network Slicing:
 
@@ -227,8 +227,7 @@ The term "Transport Network" is used for disambiguation with 5G network (e.g., I
 
    * TN Slicing:
 
-      The term "TN slice" is used in this document to
-      refer to a slice in the Transport Network domain of the overall 5G
+      The term "TN slice" refers to a slice in the Transport Network domain of the overall 5G
       architecture.
 
       The objective of TN Slicing is to isolate,


### PR DESCRIPTION
> ---
> 
> 3.2
> 
>    Network slicing has a different meaning in the 3GPP mobile and
>    transport worlds.
> 
> Firstly, this reads with some ambiguity. I think you mean to say
> 
>    Network slicing has a different meaning in the 3GPP mobile
> world and
>    the transport world.
> 
> Second, I think we are probably limiting ourselves to the world
> made up of transport networks built from IETF technologies. So
> you might say:
> 
>    Network slicing has a different meaning in the 3GPP mobile
> world and
>    the IETF transport network world.
> 
> Lastly, this is a substantial assertion. I think your subsequent
> text is supposed to substantiate this assertion rather than be
> dependent on it.
> So maybe...
> 
> OLD
>    Hence, for the sake of precision and without
>    seeking to be exhaustive, this section provides a brief
> description
>    of the objectives of 5G Network Slicing and Transport Network
>    Slicing:
> NEW
>    This difference can be seen from the descriptions below that
> set out
>    the objectives of 5G Network Slicing and Transport Network
>    Slicing.  These descriptions are not intended to be
> exhaustive.
> END
> 
> You go on to say...
> 
>       The term "TN slice" is used in this document to refer to a
> slice
>       in the Transport Network domain of the overall 5G
> architecture.
> 
> That is fine, except that you have asserted "the transport world"
> yet you are limiting yourself to "this document." It would be
> fine to mean "this document" (in which case, fix the scope in the
> earlier assertion), and it is fine to mean "transport world," in
> which case you need (as you did for the 3G slicing case) you need
> to give a reference.