### PR TITLE
Adrian Review: Section 3.1-permits to define more precisely where

### DIFF
--- a/draft-ietf-teas-5g-ns-ip-mpls.md
+++ b/draft-ietf-teas-5g-ns-ip-mpls.md
@@ -204,7 +204,7 @@ As discussed in Section 4.4.1 of {{TS-28.530}}, the 3GPP management system does 
 
 > 'The non-3GPP part includes TN parts. The 3GPP management system provides the network slice requirements to the corresponding management systems of those non-3GPP parts, e.g. the TN part supports connectivity within and between CN and AN parts.' (Section 4.4.1 of {{TS-28.530}})
 
-In practice, the TN may not map to a monolithic architecture and management domain. It is frequently segmented, non-uniform, and managed by different entities. For example, {{fig-1}} depicts a NF instance that is deployed in an edge data center (DC) connected to a NF located in a Public Cloud via a WAN (e.g., MPLS-VPN service). In this example, the TN can be seen as an abstraction representing an end-to-end connectivity based upon three distinct domains: DC, WAN, and Public Cloud. A model for the Transport Network based on orchestration domains is introduced in {{sec-orch}}. This model permits to define more precisely where the RFC 9543 Network Slices apply.
+In practice, the TN may not map to a monolithic architecture and management domain. It is frequently segmented, non-uniform, and managed by different entities. For example, {{fig-1}} depicts a NF instance that is deployed in an edge data center (DC) connected to a NF located in a Public Cloud via a WAN (e.g., MPLS-VPN service). In this example, the TN can be seen as an abstraction representing an end-to-end connectivity based upon three distinct domains: DC, WAN, and Public Cloud. A model for the Transport Network based on orchestration domains is introduced in {{sec-orch}}.
 
 ~~~~
 {::include ./drawings/TN-abstraction.txt}
@@ -335,7 +335,7 @@ Provider Network Orchestration domain:
 : As defined in {{!RFC9543}}, the provider relies on a Network Slice Controller (NSC) to manage and orchestrate RFC 9543 Network Slices in the provider network. This framework permits to manage connectivity together with SLOs.
 
 Customer Site Orchestration domain:
-: The Orchestration of TN elements of the customer sites relies upon a variety of  controllers (e.g., Fabric Manager, Element Management System, or VIM). The realization of this segment does not involve the Transport Network Orchestration.
+: The Orchestration of TN elements of the customer sites relies upon a variety of  controllers (e.g., Fabric Manager, Element Management System, or VIM).
 
 A TN slice relies upon resources that can involve both the provider and customer TN domains. More details are provided in {{sec-tn-nsi}}.
 


### PR DESCRIPTION
> ---
> 
> 3.1 says
>    A model for the Transport Network based on
>    orchestration domains is introduced in Section 3.4.  This
> model
>    permits to define more precisely where the RFC 9543 Network
> Slices
>    apply.
> 
> That sent me jumping ahead to 3.4 principally to discover the
> converse, that is, where 9543 slices do not apply. My immediate
> concern was that you would be stating that slicing of networks
> that use IETF technologies could somehow be done using a
> different approach.
> 
> In fact, as far as I can tell, 3.4 only talks about TNs that use
> IETF technologies, and only talks about 9543 as the slicing model
> for those TNs.
> 
> So I am unclear about the second sentence quoted. Perhaps it is
> just unnecessary?
> 

[Med] Good point. The text does not clearly convey the intent we had. We focus on the use of the framework in the provider network. We don't make any assumption whether the framework is also used in the customer site. We don't assume nor preclude that use as well.