### PR TITLE
Adrian Review: Section 3.1-disambiguation

### DIFF
--- a/draft-ietf-teas-5g-ns-ip-mpls.md
+++ b/draft-ietf-teas-5g-ns-ip-mpls.md
@@ -211,7 +211,6 @@ In practice, the TN may not map to a monolithic architecture and management doma
 ~~~~
 {: #fig-1 title="An Example of Transport Network Decomposition" artwork-align="center"}
 
-The term "Transport Network" is used for disambiguation with 5G network (e.g., IP, packet-based forwarding vs RAN and CN). Consequently, the disambiguation applies to Transport Network Slicing vs. 5G End-to-End Network Slicing ({{sec-5gtn}}) as well the management domains: RAN, CN, and TN domains.
 
 ##  5G Network Slicing versus Transport Network Slicing {#sec-5gtn}
 


### PR DESCRIPTION
> ---
> 
> 3.1
> 
>    The term "Transport Network" is used for disambiguation with
> 5G
>    network (e.g., IP, packet-based forwarding vs RAN and CN).
>    Consequently, the disambiguation applies to Transport Network
> Slicing
>    vs. 5G End-to-End Network Slicing (Section 3.2) as well the
>    management domains: RAN, CN, and TN domains.
> 
> I thought I understood what was meant by TN in this document
> until I reached this paragraph. The previous text in 3.1 (and in
> the references) seems clear as to what a TN is. This text,
> however, confuses me and I can't extract anything useful from it.
> After all, haven't you just explained that:
> 
>    Appendix B provides an overview of 5G network building blocks:
> the
>    Radio Access Network (RAN), Core Network (CN), and Transport
> Network
>    (TN).  The Transport Network is defined by the 3GPP as the
> "part
>    supporting connectivity within and between CN and RAN parts"
>    (Section 1 of [TS-28.530]).
>