### PR TITLE
Adrian Review: Section 3.3-reference design

### DIFF
--- a/draft-ietf-teas-5g-ns-ip-mpls.md
+++ b/draft-ietf-teas-5g-ns-ip-mpls.md
@@ -245,7 +245,7 @@ The term "Transport Network" is used for disambiguation with 5G network (e.g., I
 
 ## Transport Network Reference Design {#sec-ref-design}
 
-{{fig-tn-arch}} depicts the reference design used for modelling the Transport Network based on management perimeters (Customer vs. Provider).
+{{fig-tn-arch}} depicts the reference design used in this document for modelling the Transport Network based on management perimeters (Customer vs. Provider).
 
 ~~~~
 {::include ./drawings/pe-ce-ac.txt}


### PR DESCRIPTION
> 3.3
> 
>    Figure 2 depicts the reference design used for modelling the
>    Transport Network based on management perimeters (Customer vs.
>    Provider).
> 
> Is that "...used in this document for modelling..."? In which
> case I have no objection so long as you make this clear.
> Or are you being more prescriptive for the general case? If so,
> then I have significant concerns because you have imposed a
> restriction to only one of the cases shown in Figure 1 of RFC
> 9543.