### PR TITLE
Adrian Review: Section 3.3.1

### DIFF
--- a/draft-ietf-teas-5g-ns-ip-mpls.md
+++ b/draft-ietf-teas-5g-ns-ip-mpls.md
@@ -293,10 +293,10 @@ Distributed CE:
 : An example of a distributed CE is the realization of an interconnection using a L3VPN service based on a distributed CE composed of a switch (Layer 2) and a router (Layer 3) (case (ii) in {{fig-50}}).
 
 Distributed PE:
-: The logical connectivity is realized by configuring  multiple devices in the Transport Network (provider orchestration domain). The PE function is distributed.
+: The logical connectivity is realized by configuring  multiple devices in the provider network (i.e., provider orchestration domain). The PE function is distributed.
 : An example of a distributed PE is the "Managed CE service". For example, a provider delivers VPN services using CEs and PEs which are both managed by the provider (case (iii) in {{fig-50}}). The managed CE can also be a Data Center Gateway as depicted in the example (iv) of {{fig-50}}. A provider-managed CE may attach to CEs of multiple customers. However, this device is part of the provider network.
 
-{{fig-50}} depicts the reference model together with examples of distributed CEs and PEs.
+{{fig-50}} depicts examples of distributed CEs and PEs. Deployment cases where the AC is also managed by the provider are not discussed here because the setup of such an AC does not require any coordination between the customer and provider orchestration domains.
 
 ~~~~
 {::include ./drawings/distributed-pe-ce.txt}


### PR DESCRIPTION
> 
> I wonder what section 3.3.1 adds to the document. Sure, it is a
> tutorial on distributed CEs and PEs, and I don't find any fault
> with it (although it's a bit odd to not find the provider-managed
> CE present at the customer site as one of the examples).
> 
> But you close the section saying...
> 
>    In subsequent sections of this document, the terms CE and PE
> are used
>    for both single and distributed devices.
> 
> ...so why do we need this tutorial?
> 
> I wonder whether you might successfully collapse each of the
> definitions of "distributed CE", "distributed PE", "co-managed
> CE", and "service- aware CE" into short paragraphs, and just add
> them to the terminology list (removing sections 3.3.1, 3.3.2, and
> 3.3.3).
>